### PR TITLE
Finalize work on complex cases

### DIFF
--- a/example/serializer_example.dart
+++ b/example/serializer_example.dart
@@ -44,7 +44,6 @@ main() async {
   print(Serializer.toJson(a));
   print(Serializer.toMap(a));
 
-  ModelA A = Serializer.fromJson(Serializer.toJson(a), ModelA);
-
+  ModelA A = Serializer.fromJson(Serializer.toJson(a));
   print(Serializer.toJson(A));
 }

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -33,14 +33,14 @@ abstract class Serializer {
   /// Convert the object to JSON
   static String toJson(Object obj) => _toJson(obj);
 
-  /// Convert a JSON String to the given Type
-  static Object fromJson(String json, Type type) => _fromJson(json, type);
+  /// Convert a JSON String
+  static Object fromJson(String json) => _fromJson(json);
 
-  /// Convert a Map<String, dynamic> to the given Type
-  static Object fromMap(Map json, Type type) => _fromMap(json, type);
+  /// Convert a Map<String, dynamic>
+  static Object fromMap(Map map) => _fromMap(map);
 
   /// Convert a JSON String list to a List of the given Type
-  static Object fromList(List json, Type type) => _fromList(json, type);
+  static Object fromList(List list, Type type) => _fromList(list, type);
 }
 
 /**

--- a/lib/src/convert.dart
+++ b/lib/src/convert.dart
@@ -4,6 +4,32 @@
 
 part of serializer.base;
 
+Type _findGenericOfList(Type type) {
+  String str = type.toString();
+  RegExp reg = new RegExp(r"^List<(.*)>$");
+  Iterable<Match> matches = reg.allMatches(str);
+  if (matches == null || matches.isEmpty) {
+    return null;
+  }
+  var match = matches.first.group(1);
+  switch (match) {
+    case "num":
+      return num;
+    case "String":
+      return String;
+    case "bool":
+      return bool;
+    case "int":
+      return int;
+    case "double":
+      return double;
+    case "DateTime":
+      return DateTime;
+    default:
+      return _decodeType(match);
+  }
+}
+
 bool _isSerializableVariable(DeclarationMirror vm) {
   return !vm.isPrivate;
 }
@@ -18,17 +44,10 @@ Type _decodeType(String name) {
   return classMirror?.dynamicReflectedType;
 }
 
-List _fromList(List list, Type type) {
-  List _list = new List.from(list);
-
-  for (var i = 0; i < _list.length; i++) {
-    Type _type = type;
-    if (_list[i] is Map && _list[i].containsKey(_type_info_key)) {
-      _type = _decodeType(_list[i][_type_info_key]);
-    }
-    _list[i] = _decode(_list[i], _type ?? type);
-  }
-  return _list;
+List _fromList(List list, [Type type]) {
+  List data = new List();
+  list.forEach((value) => data.add(_decode(value, type)));
+  return data;
 }
 
 bool _asMetadata(DeclarationMirror dec, Type type) {
@@ -40,16 +59,28 @@ bool _asMetadata(DeclarationMirror dec, Type type) {
   return false;
 }
 
-Object _fromMap(Map json, Type type) {
-  if (json == null || json.isEmpty) {
+Object _fromMap(Map map) {
+  if (map == null || map.isEmpty) {
     return null;
   }
-  json.remove(_type_info_key);
+  var type = _decodeType(map.remove(_type_info_key));
 
-  if (type == Map) {
-    return new Map.from(json);
+  // Only Map
+  if (type == null) {
+    Map data = new Map();
+    map.forEach((key, value){
+      if (value is Map) {
+        data[key] = _fromMap(value);
+      } else if (value is List) {
+        data[key] = _fromList(value, type);
+      } else {
+        data[key] = value;
+      }
+    });
+    return data;
   }
 
+  // Class from Map
   ClassMirror cm;
   Object obj;
   InstanceMirror instance;
@@ -62,19 +93,30 @@ Object _fromMap(Map json, Type type) {
     return null;
   }
 
-  for (var key in json.keys) {
+  for (var key in map.keys) {
     MethodMirror met = cm.instanceMembers[key];
     DeclarationMirror dec = cm.declarations[key];
     if (met != null
         && dec != null
         && _isSerializableVariable(met)
         && !_asMetadata(dec, Ignore)) {
-      if (_isPrimaryType(met.reflectedReturnType)) {
-        instance.invokeSetter(key, json[key]);
-      } else if (met.reflectedReturnType == DateTime) {
-        instance.invokeSetter(key, DateTime.parse(json[key]));
-      } else {
-        instance.invokeSetter(key, _decode(json[key], met.reflectedReturnType));
+      var _type = met.reflectedReturnType;
+      if (_isPrimaryType(_type)) {
+        instance.invokeSetter(key, map[key]);
+      } else if (_type == DateTime) {
+        instance.invokeSetter(key, DateTime.parse(map[key]));
+      } else if (_type.toString().startsWith("List")) {
+        var listOf = _findGenericOfList(_type);
+        if (_isPrimaryType(listOf)) {
+          instance.invokeSetter(key, _fromList(map[key]));
+        } else if (listOf == DateTime) {
+          instance.invokeSetter(key, _fromList(map[key], DateTime));
+        } else if (Serializer.classes.containsKey(listOf.toString())) {
+          instance.invokeSetter(key, _fromList(map[key], listOf));
+        }
+      } else if (_type.toString().startsWith("Map")
+          || Serializer.classes.containsKey(_type.toString())) {
+        instance.invokeSetter(key, _fromMap(map[key]));
       }
     }
   }
@@ -82,20 +124,22 @@ Object _fromMap(Map json, Type type) {
   return instance.reflectee;
 }
 
-Object _decode(Object decode, Type type) {
+Object _decode(Object decode, [Type type]) {
   if (decode is Map) {
-    return _fromMap(decode, type);
+    return _fromMap(decode);
   } else if (decode is List) {
     return _fromList(decode, type);
+  } else if (type == DateTime) {
+    return DateTime.parse(decode);
   }
   return decode;
 }
 
-Object _fromJson(String json, Type type) {
+Object _fromJson(String json) {
   if (json == null || json.isEmpty) {
     return null;
   }
-  return _decode(JSON.decode(json), type);
+  return _decode(JSON.decode(json));
 }
 
 List _convertList(List list) {
@@ -134,7 +178,6 @@ Map _toMap(Object obj) {
   }
   if (obj is Map) {
     Map data = new Map();
-    data[_type_info_key] = obj.runtimeType.toString();
     obj.forEach((key, value) => _convertMap(data, key, value));
     return data;
   }

--- a/test/serializer_test.dart
+++ b/test/serializer_test.dart
@@ -4,7 +4,6 @@
 
 library serializer.test;
 
-import "dart:convert";
 import "package:test/test.dart";
 import "package:serializer/serializer.dart";
 
@@ -108,7 +107,7 @@ main() {
       Map a = {"test": "toto", "titi": new ModelA()};
       String json = Serializer.toJson(a);
       String mapType = (new Map()).runtimeType.toString();
-      expect('{"test":"toto","titi":{"@dart_type":"ModelA","foo":"bar"},"@dart_type":"' + mapType + '"}', json);
+      expect('{"@dart_type":"' + mapType + '","test":"toto","titi":{"@dart_type":"ModelA","foo":"bar"}}', json);
     });
 
     test("list", () {
@@ -116,7 +115,7 @@ main() {
 
       String json = Serializer.toJson(list);
       expect(
-          '["{\\"@dart_type\\":\\"ModelA\\",\\"foo\\":\\"toto\\"}","{\\"@dart_type\\":\\"ModelA\\",\\"foo\\":\\"bar\\"}"]',
+          '[{"@dart_type":"ModelA","foo":"toto"},{"@dart_type":"ModelA","foo":"bar"}]',
           json);
     });
 
@@ -126,7 +125,7 @@ main() {
       String json = test.toJson();
 
       expect(
-          '{"@dart_type":"ModelD","tests":["{\\"@dart_type\\":\\"ModelA\\",\\"foo\\":\\"toto\\"}","{\\"@dart_type\\":\\"ModelA\\",\\"foo\\":\\"bar\\"}"]}',
+          '{"@dart_type":"ModelD","tests":[{"@dart_type":"ModelA","foo":"toto"},{"@dart_type":"ModelA","foo":"bar"}]}',
           json);
     });
 
@@ -158,7 +157,7 @@ main() {
       List list = [new ModelB(), new ModelB()];
       String json = Serializer.toJson(list);
       expect(
-          '["{\\"@dart_type\\":\\"ModelB\\",\\"toto\\":\\"tata\\"}","{\\"@dart_type\\":\\"ModelB\\",\\"toto\\":\\"tata\\"}"]',
+          '[{"@dart_type":"ModelB","toto":"tata"},{"@dart_type":"ModelB","toto":"tata"}]',
           json);
     });
 
@@ -168,7 +167,7 @@ main() {
       String json = Serializer.toJson(listB);
       print(json);
       expect(
-          '["{\\"@dart_type\\":\\"ModelB\\",\\"toto\\":\\"tata\\"}",["{\\"@dart_type\\":\\"ModelB\\",\\"toto\\":\\"tata\\"}","{\\"@dart_type\\":\\"ModelB\\",\\"toto\\":\\"tata\\"}"]]',
+          '[{"@dart_type":"ModelB","toto":"tata"},[{"@dart_type":"ModelB","toto":"tata"},{"@dart_type":"ModelB","toto":"tata"}]]',
           json);
     });
 
@@ -176,7 +175,7 @@ main() {
       List list = [new ModelC(), new ModelC()];
       String json = Serializer.toJson(list);
       expect(
-          '["{\\"@dart_type\\":\\"ModelC\\",\\"foo\\":{\\"@dart_type\\":\\"ModelA\\",\\"foo\\":\\"bar\\"},\\"plop\\":\\"titi\\"}","{\\"@dart_type\\":\\"ModelC\\",\\"foo\\":{\\"@dart_type\\":\\"ModelA\\",\\"foo\\":\\"bar\\"},\\"plop\\":\\"titi\\"}"]',
+          '[{"@dart_type":"ModelC","foo":{"@dart_type":"ModelA","foo":"bar"},"plop":"titi"},{"@dart_type":"ModelC","foo":{"@dart_type":"ModelA","foo":"bar"},"plop":"titi"}]',
           json);
     });
 
@@ -232,7 +231,7 @@ main() {
 
     test("list - fromJson", () {
       List list = Serializer.fromJson(
-          '["{\\"@dart_type\\":\\"ModelA\\",\\"foo\\":\\"toto\\"}","{\\"@dart_type\\":\\"ModelA\\",\\"foo\\":\\"bar\\"}"]',
+          '[{"@dart_type":"ModelA","foo":"toto"},{"@dart_type":"ModelA","foo":"bar"}]',
           ModelA);
 
       expect(2, list.length);
@@ -245,8 +244,7 @@ main() {
 
     test("list - fromList", () {
       List list = Serializer.fromList(
-          JSON.decode(
-              '["{\\"@dart_type\\":\\"ModelA\\",\\"foo\\":\\"toto\\"}","{\\"@dart_type\\":\\"ModelA\\",\\"foo\\":\\"bar\\"}"]'),
+          [{"@dart_type":"ModelA","foo":"toto"},{"@dart_type":"ModelA","foo":"bar"}],
           ModelA);
 
       expect(2, list.length);
@@ -259,7 +257,7 @@ main() {
 
     test("inner list 1", () {
       ModelD test = Serializer.fromJson(
-          '{"@dart_type":"ModelD","tests":["{\\"@dart_type\\":\\"ModelA\\",\\"foo\\":\\"toto\\"}","{\\"@dart_type\\":\\"ModelA\\",\\"foo\\":\\"bar\\"}"]}',
+          '{"@dart_type":"ModelD","tests":[{"@dart_type":"ModelA","foo":"toto"},{"@dart_type":"ModelA","foo":"bar"}]}',
           ModelD);
 
       expect(2, test?.tests?.length);

--- a/test/serializer_test.dart
+++ b/test/serializer_test.dart
@@ -349,11 +349,10 @@ main() {
           ..boolSet    = { "ok": true, "nok": false }
           ..intSet     = { "intA": 1, "intB": 12 }
           ..doubleSet  = { "dblA": 1, "dblB": 12 }
-//          ..dateSet    = { "fiesta": new DateTime(2016,12,24), "christmas": new DateTime(2016,12,25) }
+          ..dateSet    = { "fiesta": new DateTime(2016,12,24), "christmas": new DateTime(2016,12,25) }
           ..ignoreSet  = { "A": new WithIgnore("1337A", "42A", "ThisIsASecretA"), "B": new WithIgnore("1337B", "42B", "ThisIsASecretB") };
       var json = Serializer.toJson(complex);
-//      expect(json, '{"@dart_type":"Complex","nums":[1,2.2,3],"strings":["1","2","3"],"bools":[true,false,true],"ints":[1,2,3],"doubles":[1.1,2.2,3.3],"dates":["2016-12-24T00:00:00.000","2016-12-25T00:00:00.000","2016-12-26T00:00:00.000"],"ignores":[{"@dart_type":"WithIgnore","a":"1337A","b":"42A"},{"@dart_type":"WithIgnore","a":"1337B","b":"42B"}],"numSet":{"numA":1,"numB":12.2},"stringSet":{"strA":"1","strB":"3"},"boolSet":{"ok":true,"nok":false},"intSet":{"intA":1,"intB":12},"doubleSet":{"dblA":1,"dblB":12},"dateSet":{"fiesta":"2016-12-24T00:00:00.000","christmas":"2016-12-25T00:00:00.000"},"ignoreSet":{"A":{"@dart_type":"WithIgnore","a":"1337A","b":"42A"},"B":{"@dart_type":"WithIgnore","a":"1337B","b":"42B"}}}');
-      expect(json, '{"@dart_type":"Complex","nums":[1,2.2,3],"strings":["1","2","3"],"bools":[true,false,true],"ints":[1,2,3],"doubles":[1.1,2.2,3.3],"dates":["2016-12-24T00:00:00.000","2016-12-25T00:00:00.000","2016-12-26T00:00:00.000"],"ignores":[{"@dart_type":"WithIgnore","a":"1337A","b":"42A"},{"@dart_type":"WithIgnore","a":"1337B","b":"42B"}],"numSet":{"numA":1,"numB":12.2},"stringSet":{"strA":"1","strB":"3"},"boolSet":{"ok":true,"nok":false},"intSet":{"intA":1,"intB":12},"doubleSet":{"dblA":1,"dblB":12},"ignoreSet":{"A":{"@dart_type":"WithIgnore","a":"1337A","b":"42A"},"B":{"@dart_type":"WithIgnore","a":"1337B","b":"42B"}}}');
+      expect(json, '{"@dart_type":"Complex","nums":[1,2.2,3],"strings":["1","2","3"],"bools":[true,false,true],"ints":[1,2,3],"doubles":[1.1,2.2,3.3],"dates":["2016-12-24T00:00:00.000","2016-12-25T00:00:00.000","2016-12-26T00:00:00.000"],"ignores":[{"@dart_type":"WithIgnore","a":"1337A","b":"42A"},{"@dart_type":"WithIgnore","a":"1337B","b":"42B"}],"numSet":{"numA":1,"numB":12.2},"stringSet":{"strA":"1","strB":"3"},"boolSet":{"ok":true,"nok":false},"intSet":{"intA":1,"intB":12},"doubleSet":{"dblA":1,"dblB":12},"dateSet":{"fiesta":"2016-12-24T00:00:00.000","christmas":"2016-12-25T00:00:00.000"},"ignoreSet":{"A":{"@dart_type":"WithIgnore","a":"1337A","b":"42A"},"B":{"@dart_type":"WithIgnore","a":"1337B","b":"42B"}}}');
     });
 
     test("Deserialize", () {
@@ -377,7 +376,7 @@ main() {
       expect(complex.boolSet  , { "ok": true, "nok": false });
       expect(complex.intSet   , { "intA": 1, "intB": 12 });
       expect(complex.doubleSet, { "dblA": 1, "dblB": 12 });
-//      expect(complex.dateSet  , { "fiesta": new DateTime(2016,12,24), "christmas": new DateTime(2016,12,25) });
+      expect(complex.dateSet  , { "fiesta": new DateTime(2016,12,24), "christmas": new DateTime(2016,12,25) });
       expect(complex.ignoreSet["A"].a,      "1337A");
       expect(complex.ignoreSet["A"].b,      "42A");
       expect(complex.ignoreSet["A"].secret, null);


### PR DESCRIPTION
Finalize the work started on #13 

`List<>` and `Map<>` fields are now supported.
Only `Map<String,DateTime>` isn't supported, but can be replaced by a workaround as following

``` dart
class Date {
  DateTime date;
}
class A {
  Map<String, Date> dates:
}
```
