### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.4.0
+
+- Add DateTimeUtcCodec an UTC DateTime codec.
+- Add ObjectId A simple ObjectId codec (for Mongo BSON).
+
+**Breaking changes:**
+
+- Move codecs/codec.dart to codecs.dart
+- In class Serialize, serializer getter is no more static.
+- Remove DateTimeCodec from Serializer.Json and Serializer.TypedJson factories
+
 ## 0.3.2
 - Support cyclical objects (@referenceable & @reference annotations)
 - Support SerializedName class inheritance

--- a/example/serializer_example.dart
+++ b/example/serializer_example.dart
@@ -47,7 +47,7 @@ main() {
   print(b.toMap());
   print(c.toJson());
 
-  var sz = TypedJsonObject.serializer;
+  var sz = new Serializer.TypedJson();
   print(sz.toMap(a));
   print(sz.encode(a));
 

--- a/lib/codecs.dart
+++ b/lib/codecs.dart
@@ -2,7 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library serializer.codec;
+library serializer.codecs;
 
-export 'type_codec.dart';
-export 'date_time.dart';
+export 'codecs/type_codec.dart';
+export 'codecs/date_time.dart';
+export 'codecs/date_time_utc.dart';
+export 'codecs/object_id.dart';

--- a/lib/codecs/date_time_utc.dart
+++ b/lib/codecs/date_time_utc.dart
@@ -4,8 +4,8 @@
 
 import 'type_codec.dart';
 
-/// A simple DateTime codec.
-class DateTimeCodec extends TypeCodec<DateTime> {
+/// A UTC DateTime codec.
+class DateTimeUtcCodec extends TypeCodec<DateTime> {
   DateTime decode(dynamic value) => DateTime.parse(value);
-  dynamic encode(DateTime value) => value.toIso8601String();
+  dynamic encode(DateTime value) => value.toUtc().toIso8601String();
 }

--- a/lib/codecs/object_id.dart
+++ b/lib/codecs/object_id.dart
@@ -2,10 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:bson/bson.dart';
 import 'type_codec.dart';
 
-/// A simple DateTime codec.
-class DateTimeCodec extends TypeCodec<DateTime> {
-  DateTime decode(dynamic value) => DateTime.parse(value);
-  dynamic encode(DateTime value) => value.toIso8601String();
+/// A simple ObjectId codec.
+class ObjectIdCodec extends TypeCodec<ObjectId> {
+  ObjectId decode(dynamic value) => value is ObjectId ? value : ObjectId.parse(value);
+  dynamic encode(ObjectId value) => value;
 }

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 
 import 'package:reflectable/reflectable.dart';
 import 'package:serializer/codecs/type_codec.dart';
-import 'package:serializer/codecs/date_time.dart';
 
 import 'annotations.dart';
 import "convert.dart";
@@ -19,7 +18,7 @@ final _SerializerTypedJson = new Serializer.TypedJson();
 abstract class Serialize {
   /// Get the serializer instance
   @ignore
-  static Serializer get serializer => null;
+  Serializer get serializer;
 
   /// Convert the object to a map
   Map toMap() => serializer?.toMap(this);
@@ -34,17 +33,16 @@ abstract class Serialize {
 @serializable
 abstract class JsonObject extends Serialize {
   /// Get the JSON serializer instance
-  ///
   @ignore
-  static Serializer get serializer => _SerializerJson;
+  Serializer get serializer => _SerializerJson;
 
   /// Convert the object to JSON string
   String toJson() => encode();
 
   /// Convert the object to a map
-  Map toMap() => serializer?.toMap(this);
+  Map toMap() => serializer.toMap(this);
 
-  String encode() => serializer?.encode(this);
+  String encode() => serializer.encode(this);
 }
 
 /// Utility class for a typed JSON object
@@ -52,13 +50,13 @@ abstract class JsonObject extends Serialize {
 abstract class TypedJsonObject extends Serialize {
   /// Get the typed JSON serializer instance
   @ignore
-  static Serializer get serializer => _SerializerTypedJson;
+  Serializer get serializer => _SerializerTypedJson;
 
   /// Convert the object to a map
-  Map toMap() => _SerializerTypedJson.toMap(this);
+  Map toMap() => serializer.toMap(this);
 
   /// Convert the object to JSON string
-  String toJson() => _SerializerTypedJson.encode(this);
+  String toJson() => serializer.encode(this);
 }
 
 /// Utility class to access to the serializer api
@@ -84,17 +82,15 @@ class Serializer {
     initSingletonClasses();
   }
 
-  /// Create a default JSON serializer plus a simple DateTime codec
+  /// Create a default JSON serializer
   factory Serializer.Json() {
-    return new Serializer()
-      ..addTypeCodec(DateTime, new DateTimeCodec());
+    return new Serializer(JSON);
   }
 
-  /// Create a default JSON serializer plus a simple DateTime codec
+  /// Create a default JSON serializer
   /// with '@type' added field
   factory Serializer.TypedJson() {
-    return new Serializer(JSON, "@type")
-      ..addTypeCodec(DateTime, new DateTimeCodec());
+    return new Serializer(JSON, "@type");
   }
 
   /// Registers a [typeCodec] for the specific [type]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: serializer
 description: Serialization to JSON using reflectable
-version: 0.3.2
+version: 0.4.0
 authors:
   - Hadrien Lejard <hadrien.lejard@gmail.com>
   - Stéphane Este-Gracias <sestegra@gmail.com>
@@ -11,6 +11,7 @@ environment:
   sdk: '>=1.0.0 <2.0.0'
 
 dependencies:
+  bson: '^0.2.0'
   reflectable: ">=0.5.0"
 
 dev_dependencies:

--- a/test/double_json_test.dart
+++ b/test/double_json_test.dart
@@ -5,13 +5,16 @@
 import 'package:test/test.dart';
 import 'package:serializer/serializer.dart';
 
+final _jsonSerializer = new Serializer.Json();
+final _typedDsonSerializer = new Serializer.TypedJson();
+
 @serializable
 class DoubleSimple extends JsonObject {
   double test = 1.1;
 
   DoubleSimple();
-  factory DoubleSimple.fromJson(String json) => JsonObject.serializer?.decode(json, DoubleSimple);
-  factory DoubleSimple.fromMap(Map map) => JsonObject.serializer?.fromMap(map, DoubleSimple);
+  factory DoubleSimple.fromJson(String json) => _jsonSerializer.decode(json, DoubleSimple);
+  factory DoubleSimple.fromMap(Map map) => _jsonSerializer.fromMap(map, DoubleSimple);
 }
 
 @serializable
@@ -20,8 +23,8 @@ class DoubleComplex extends JsonObject {
   List<double> list = [1.1, 2.2, 3.3];
 
   DoubleComplex();
-  factory DoubleComplex.fromJson(String json) => JsonObject.serializer?.decode(json, DoubleComplex);
-  factory DoubleComplex.fromMap(Map map) => JsonObject.serializer?.fromMap(map, DoubleComplex);
+  factory DoubleComplex.fromJson(String json) => _typedDsonSerializer.decode(json, DoubleComplex);
+  factory DoubleComplex.fromMap(Map map) => _typedDsonSerializer.fromMap(map, DoubleComplex);
 }
 
 main() {

--- a/test/json_test.dart
+++ b/test/json_test.dart
@@ -21,14 +21,11 @@ abstract class ProxyA extends Proxy {}
 class ModelInt extends ProxyA {
   int _bar;
 
-
   int get bar => _bar;
 
   set bar(int value) => _bar = value;
 
   ModelInt([this._bar = 42]);
-
- factory ModelInt.fromJson(String json) => JsonObject.serializer?.decode(json, ModelInt);
 }
 
 @serializable
@@ -41,7 +38,6 @@ class ModelDouble extends ProxyA {
 @serializable
 class ModelA extends ProxyA {
   String _foo;
-
 
   String get foo => _foo;
 
@@ -98,9 +94,15 @@ class WithIgnore extends ProxyA {
   WithIgnore([this.a, this.b, this.secret]);
 }
 
+Serializer _dateSerializer = new Serializer.Json()
+  ..addTypeCodec(DateTime, new DateTimeCodec());
+
 @serializable
 class Date extends ProxyA {
   DateTime date = new DateTime.now();
+
+  @ignore
+  Serializer get serializer => _dateSerializer;
 
   Date([this.date]);
 }
@@ -168,7 +170,8 @@ Serializer serializer;
 
 main() {
   setUpAll(() {
-    serializer = new Serializer.Json();
+    serializer = new Serializer.Json()
+        ..addTypeCodec(DateTime, new DateTimeCodec());
   });
 
   tearDownAll(() {
@@ -441,12 +444,6 @@ main() {
       ModelDouble d = serializer.decode(
           '{"bar":42.1}', ModelDouble);
       expect(d.bar, 42.1);
-    });
-
-    test("Test JsonObject", () {
-      ModelInt a = new ModelInt.fromJson('{"bar": 12}');
-
-      expect(a.bar, 12);
     });
   });
 

--- a/test/json_test.dart
+++ b/test/json_test.dart
@@ -4,6 +4,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
+import 'package:serializer/codecs.dart';
 import 'package:serializer/serializer.dart';
 import "package:serializer/src/convert.dart";
 

--- a/test/typed_json_test.dart
+++ b/test/typed_json_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
+import 'package:serializer/codecs.dart';
 import 'package:serializer/serializer.dart';
 
 

--- a/test/typed_json_test.dart
+++ b/test/typed_json_test.dart
@@ -86,9 +86,14 @@ class TypedWithIgnore extends TypedProxyA {
   TypedWithIgnore([this.a, this.b, this.secret]);
 }
 
+Serializer _dateSerializer = new Serializer.TypedJson()
+    ..addTypeCodec(DateTime, new DateTimeCodec());
 @serializable
 class TypedDate extends TypedProxyA {
   DateTime date = new DateTime.now();
+
+  @ignore
+  Serializer get serializer => _dateSerializer;
 
   TypedDate([this.date]);
 }
@@ -153,7 +158,8 @@ class Address {
 }
 
 main() {
-  var serializer = new Serializer.TypedJson();
+  var serializer = new Serializer.TypedJson()
+      ..addTypeCodec(DateTime, new DateTimeCodec());
 
 
   group("Serialize", () {


### PR DESCRIPTION
- Add DateTimeUtcCodec an UTC DateTime codec.
- Add ObjectId a simple ObjectId codec (for Mongo BSON).

**Breaking changes:**
- Move codecs/codec.dart to codecs.dart
- In class Serialize, serializer getter is no more static.
- Remove DateTimeCodec from Serializer.Json and Serializer.TypedJson factories
