### PR TITLE
Decode not feasible with only a getter

### DIFF
--- a/test/codegen/json_test.codec.dart
+++ b/test/codegen/json_test.codec.dart
@@ -491,6 +491,33 @@ class MixinCodec extends TypeCodec<Mixin> {
   String get typeInfo => 'Mixin';
 }
 
+// **************************************************************************
+// Generator: SerializerGenerator
+// Target: class GetterOnly
+// **************************************************************************
+
+class GetterOnlyCodec extends TypeCodec<GetterOnly> {
+  @override
+  GetterOnly decode(dynamic value, {Serializer serializer}) {
+    GetterOnly obj = new GetterOnly();
+    return obj;
+  }
+
+  @override
+  dynamic encode(GetterOnly value,
+      {Serializer serializer, bool useTypeInfo, bool withTypeInfo}) {
+    Map<String, dynamic> map = new Map<String, dynamic>();
+    if (serializer.enableTypeInfo(useTypeInfo, withTypeInfo)) {
+      map[serializer.typeInfoKey] = typeInfo;
+    }
+    map['value'] = value.value;
+    return cleanNullInMap(map);
+  }
+
+  @override
+  String get typeInfo => 'GetterOnly';
+}
+
 Map<String, TypeCodec<dynamic>> test_codegen_json_test_codecs =
     <String, TypeCodec<dynamic>>{
   'ModelInt': new ModelIntCodec(),
@@ -507,4 +534,5 @@ Map<String, TypeCodec<dynamic>> test_codegen_json_test_codecs =
   'TestMaxSuperClass': new TestMaxSuperClassCodec(),
   'Complex': new ComplexCodec(),
   'Mixin': new MixinCodec(),
+  'GetterOnly': new GetterOnlyCodec(),
 };

--- a/test/codegen/json_test.dart
+++ b/test/codegen/json_test.dart
@@ -145,6 +145,14 @@ class Mixin extends ProxyA with M1, M2 {
   String b;
 }
 
+@serializable
+class GetterOnly {
+  String _value;
+  String get value => _value;
+
+  GetterOnly([this._value]);
+}
+
 Serializer serializer;
 
 main() {
@@ -354,6 +362,11 @@ main() {
   });
 
   group("Deserialize", () {
+    test("getter only", () {
+      GetterOnly getterOnly = serializer.decode('{"value":"foo"}', type: GetterOnly) as GetterOnly;
+      expect(getterOnly.value, "foo");
+    });
+
     test("simple test - fromJson", () {
       ModelA a = serializer.decode('{"foo":"toto"}', type: ModelA);
 


### PR DESCRIPTION
In the given test, 'value' can't be set when decoding.
A warning should be written in the documentation.

Don't merge this pull request.

```
@serializable
class GetterOnly {
  String _value;
  String get value => _value;
 
  GetterOnly([this._value]);
}
```